### PR TITLE
Adding shellwords require to prevent NoMethodError

### DIFF
--- a/lib/mina/appsignal/tasks.rb
+++ b/lib/mina/appsignal/tasks.rb
@@ -22,6 +22,7 @@
 
 require 'mina/rails'
 require 'json'
+require 'shellwords'
 
 # ## Settings
 # Any and all of these settings can be overriden in your `deploy.rb`.


### PR DESCRIPTION
appsignal_local_username is fetched from `whoami` command and then `shellescape`-d, but if the lib is not required elsewhere the deploy will fail.

Closes #1
